### PR TITLE
Exports for VS2013 and package.json for Default require usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Dan BROOKS",
   "license": "BSD",
   "readmeFilename": "README.md",
+  "main": "tfs-unlock.js",
   "dependencies": {
     "sleep": "~1.1.0"
   },

--- a/tfs-unlock.js
+++ b/tfs-unlock.js
@@ -111,6 +111,10 @@ exports.vs2012 = {
 	"bit32": 'C:/Program Files/Microsoft Visual Studio 11.0/Common7/IDE/',
 	"bit64": 'C:/Program Files (x86)/Microsoft Visual Studio 11.0/Common7/IDE/'
 };
+exports.vs2013 = {
+	"bit32": 'C:/Program Files/Microsoft Visual Studio 12.0/Common7/IDE/',
+	"bit64": 'C:/Program Files (x86)/Microsoft Visual Studio 12.0/Common7/IDE/'
+};
 
 // for test suite
 exports.shell = shell;


### PR DESCRIPTION
I added in an additional export to the module for vs2013 paths.

Also included is a commit to edit the package.json for the module. This adds in the "main" property. This is done so that

```
var tfs = require('tfs-unlock');
```

can be performed by a consuming script.
