### PR TITLE
Use FileName with white space

### DIFF
--- a/tfs-unlock.js
+++ b/tfs-unlock.js
@@ -105,7 +105,7 @@ _handlePaths = function (paths, command) {
 			exists,
 			log = '';
 		filepath = fs.realpathSync(filepath); // resolve full path
-		commandLine = "tf.exe " + command + " " + filepath;
+		commandLine = "tf.exe " + command + " \"" + filepath + "\"";
 		exists = fs.existsSync(filepath);
 
 		if (exists) {


### PR DESCRIPTION
Adding quotes allow to have file name with whitespace.
Ex: ..../Employee Directory.jpg -> ".../Employee Directory.jpg" 
