### PR TITLE
Attempts to use env variables to locate TF.exe.

### DIFF
--- a/tfs-unlock.js
+++ b/tfs-unlock.js
@@ -135,18 +135,33 @@ _handlePaths = function (paths, command) {
 };
 findVisualStudioPath = function () {
 	var wd;
-	for (var ver in paths) {
-		if (paths.hasOwnProperty(ver)) {
-			for (var dirPath in paths[ver]) {
-				if (paths[ver].hasOwnProperty(dirPath)) {
-					if (fs.existsSync(paths[ver][dirPath]) && fs.existsSync(path.join(paths[ver][dirPath], 'tf.exe'))) {
-						wd = paths[ver][dirPath];
+	
+	var testEnvVar = function(envVarPath) {
+		var tfPath = path.join(envVarPath, '../IDE/tf.exe');
+		
+		return fs.existsSync(tfPath);
+	};
+	
+	if (process.env.VS140COMNTOOLS && testEnvVar(process.env.VS140COMNTOOLS)) {
+		return path.join(process.env.VS140COMNTOOLS, '../IDE');
+	} else if (process.env.VS120COMNTOOLS && testEnvVar(process.env.VS120COMNTOOLS)) {
+		return path.join(process.env.VS120COMNTOOLS, '../IDE');
+	} else if (process.env.VS110COMNTOOLS && testEnvVar(process.env.VS110COMNTOOLS)) {
+		return path.join(process.env.VS110COMNTOOLS, '../IDE');
+	} else{
+		for (var ver in paths) {
+			if (paths.hasOwnProperty(ver)) {
+				for (var dirPath in paths[ver]) {
+					if (paths[ver].hasOwnProperty(dirPath)) {
+						if (fs.existsSync(paths[ver][dirPath]) && fs.existsSync(path.join(paths[ver][dirPath], 'tf.exe'))) {
+							wd = paths[ver][dirPath];
+						}
 					}
 				}
 			}
 		}
+		return wd;
 	}
-	return wd;
 };
 
 exports.init = function (param) {


### PR DESCRIPTION
Uses the visual studio environment variables, VS140COMNTOOLS, VS120COMNTOOLS,and VS110COMNTOOLS which are added to the system to find tf.exe before rolling back to the hardcoded paths.

I've found with our new laptops and how IT set them up it is more reliable to look to these environment variables to find where things are located. For instance, on my new laptop they pre-installed my MSDN account and tf.exe was located in: D:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE. The VS140COMNTOOLS points to D:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\
