### PR TITLE
Use path.resolve to omit a resolving of symlinks

### DIFF
--- a/tfs-unlock.js
+++ b/tfs-unlock.js
@@ -104,7 +104,7 @@ _handlePaths = function (paths, command) {
 			deferred = Q.defer(),
 			exists,
 			log = '';
-		filepath = fs.realpathSync(filepath); // resolve full path
+		filepath = path.resolve(filepath); // resolve full path
 		commandLine = "tf.exe " + command + " \"" + filepath + "\"";
 		exists = fs.existsSync(filepath);
 


### PR DESCRIPTION
I have a symlinked TFS folder: `d:\tfs -> c:\d\tfs`.
If I call `tfs.undo("d:\\tfs\\readme.txt")` it executes 
`tf.exe undo /noprompt c:\d\tfs\readme.txt`. The path is wrong, so it finishes with error. The expected command is 
`tf.exe undo /noprompt d:\tfs\readme.txt`.
This PR replaces the fs.realpathSync method that resolves symlinks by the path.resolve that doesn't do that.