### PR TITLE
Added Community and Enterprise Visual Studio versions

### DIFF
--- a/tfs-unlock.js
+++ b/tfs-unlock.js
@@ -211,6 +211,14 @@ paths = {
     vs2017: {
         "bit32": 'C:\\Program Files\\Microsoft Visual Studio\\2017\\Professional\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer\\',
         "bit64": 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Professional\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer\\'
+	},
+    vs2017Community: {
+        "bit32": 'C:\\Program Files\\Microsoft Visual Studio\\2017\\Community\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer\\',
+        "bit64": 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer\\'
+	},
+    vs2017Enterprise: {
+        "bit32": 'C:\\Program Files\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer\\',
+        "bit64": 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer\\'
 	}
 };
 
@@ -220,6 +228,9 @@ exports.vs2012 = paths.vs2012;
 exports.vs2013 = paths.vs2013;
 exports.vs2015 = paths.vs2015;
 exports.vs2017 = paths.vs2017;
+exports.vs2017Professional = paths.vs2017;
+exports.vs2017Community = paths.vs2017Community;
+exports.vs2017Enterprise = paths.vs2017Enterprise;
 
 // for test suite
 exports.shell = shell;


### PR DESCRIPTION
tfs-unlock does not work with Visual Studio Community and Enterprise out of the box right now. I know of the "visualStudioPath" setting, but other projects using tfs-unlock, like gulp-tfs-checkout, do not allow setting this. Additionally, when working in a team the "visualStudioPath" can cause problems if not all of the members use the same version.

Because this project already has some Visual Studio version detection code, I added Community and Enterprise versions.

See Issue: https://github.com/danactive/tfs-unlock/issues/18